### PR TITLE
exclude png and ico from substitution

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,4 +1,5 @@
 [template]
+exclude = ["*.png", "*.ico"]
 
 [placeholders]
 account_id = { prompt = "Enter your account id", type = "string" }


### PR DESCRIPTION
they're caused the following error to occur when I ran  

cargo generate xtuc/workers-rust-template

the error was:
Error: Substitution skipped, found invalid syntax in
	src/ui/public/favicon.ico
	src/ui/public/logo192.png
	src/ui/public/logo512.png

this commit fixes that